### PR TITLE
Fix scatterplot rendering in Firefox

### DIFF
--- a/src/charts/scatterplot.js
+++ b/src/charts/scatterplot.js
@@ -2,7 +2,6 @@ import * as d3 from 'd3';
 import * as d3Scale from 'd3-scale';
 import * as d3Axis from 'd3-axis';
 import d3Tip from 'd3-tip';
-import * as moment from 'moment';
 
 class ScatterPlot {
   constructor(el, options) {
@@ -25,9 +24,9 @@ class ScatterPlot {
 
     let x = d3Scale.scaleTime()
       .domain([d3.min(data, d => {
-        return new Date(moment(d.created_at).format('MM-DD-YYYY'));
+        return Date.parse(d.created_at)
       }), d3.max(data, d => {
-        return new Date(moment(d.created_at).format('MM-DD-YYYY'));
+        return Date.parse(d.created_at)
       })])
       .range([0, width]);
 
@@ -83,7 +82,7 @@ class ScatterPlot {
       circles.append('svg:circle')
       .attr('class', this.pointClass)
       .attr('cx', d => {
-        return x(new Date(item.created_at));
+        return x(Date.parse(item.created_at));
       })
       .transition()
       .duration(Math.floor(Math.random() * (3000-2000) + 1000))


### PR DESCRIPTION
Hi, I ran into interesting issue with scatterplot in Firefox, apparently Moment.js does not accept the `d.created_at` format and fallbacks to the browser's `Date` constructor. This however behaves differently in Firefox and results in invalid value for `cx` attribute and unusable scatterplot:
<img width="1134" alt="" src="https://user-images.githubusercontent.com/616767/52057571-a0ba4f80-2565-11e9-9e6f-c52f31e147ef.png">

This PR changes the x-scale behavior to use `Date.parse`. This fixes the behavior for Firefox, keeps the plot the same in Chrome, and removes the need to use Moment.js.